### PR TITLE
feat: add bot gateway module

### DIFF
--- a/apps/bot-gateway/package.json
+++ b/apps/bot-gateway/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bot-gateway",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.5.2",
+  "dependencies": {
+    "axios": "^1.11.0",
+    "dotenv": "^17.2.1",
+    "telegraf": "^4.16.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/bot-gateway/src/index.ts
+++ b/apps/bot-gateway/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Bot starting...');

--- a/apps/bot-gateway/tsconfig.json
+++ b/apps/bot-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold bot-gateway app with Telegraf, Axios, and dotenv
- add basic TypeScript config and entry file
- add dev and build scripts for running and compiling the bot

## Testing
- `pnpm exec tsc -p apps/bot-gateway/tsconfig.json --noEmit`
- `pnpm --filter bot-gateway dev`
- `pnpm --filter bot-gateway build`
- `pnpm lint` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891fa52a2c0832497ec721fcd9a1b20