### PR TITLE
feat: add bot server with dynamic telegram webhooks

### DIFF
--- a/apps/bot-server/package.json
+++ b/apps/bot-server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bot-server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.5.2",
+  "dependencies": {
+    "body-parser": "^2.2.0",
+    "express": "^5.1.0",
+    "telegraf": "^4.16.3"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.2.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/bot-server/src/index.ts
+++ b/apps/bot-server/src/index.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import { Telegraf } from 'telegraf';
+
+type BotConfig = {
+  token: string;
+  greeting: string;
+};
+
+const botConfigs = new Map<string, BotConfig>([
+  [
+    'testbot1',
+    {
+      token: '123456789:AAbot_token_1',
+      greeting: '👋 Hello from Test Bot 1!',
+    },
+  ],
+  [
+    'testbot2',
+    {
+      token: '987654321:BBbot_token_2',
+      greeting: '👋 Welcome from Test Bot 2!',
+    },
+  ],
+]);
+
+const app = express();
+app.use(bodyParser.json());
+
+app.post('/bot/:botId/webhook', async (req, res) => {
+  const { botId } = req.params;
+  const config = botConfigs.get(botId);
+
+  if (!config) {
+    res.status(404).send('Bot not found');
+    return;
+  }
+
+  const bot = new Telegraf(config.token);
+  bot.start((ctx) => ctx.reply(config.greeting));
+
+  await bot.handleUpdate(req.body);
+  res.send('OK');
+});
+
+app.listen(3000, () => {
+  console.log('Bot server listening on port 3000');
+});

--- a/apps/bot-server/tsconfig.json
+++ b/apps/bot-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add bot-server app to manage telegram webhooks for multiple bots
- spin up express server with dynamic bot configs
- hardcode bot configs and drop dotenv usage

## Testing
- `pnpm --filter bot-server exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892ff913bc08324bee0b0cfcb97ed4d