### PR TITLE
feat: add db package for bot configs

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@botgrow/db",
+  "version": "1.0.0",
+  "main": "src/index.ts"
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export * from './memory';
+export * from './types';

--- a/packages/db/src/memory.ts
+++ b/packages/db/src/memory.ts
@@ -1,0 +1,11 @@
+import { BotConfig } from './types';
+
+const bots = new Map<string, BotConfig>();
+
+export const getBotConfig = (botId: string): BotConfig | undefined => {
+  return bots.get(botId);
+};
+
+export const addBot = (botId: string, config: BotConfig): void => {
+  bots.set(botId, config);
+};

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,0 +1,10 @@
+export type GreetingType = 'text' | 'link' | 'file';
+
+export interface BotConfig {
+  token: string;
+  greeting: {
+    type: GreetingType;
+    payload: string;
+    text?: string;
+  };
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add `@botgrow/db` workspace package for bot configuration storage
- provide memory helpers and types for bots

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: could not resolve workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_6894863429f48324b5e819e2a2e42eeb