### PR TITLE
refactor bot-server to use shared db

### DIFF
--- a/apps/bot-server/package.json
+++ b/apps/bot-server/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.5.2",
   "dependencies": {
+    "@botgrow/db": "workspace:*",
     "body-parser": "^2.2.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- switch bot-server to shared `@botgrow/db` module
- register sample bot config via `addBot`
- pull config with `getBotConfig` in webhook handler

## Testing
- `pnpm --filter bot-server build`


------
https://chatgpt.com/codex/tasks/task_e_689488d5b920832487538a21de73cfe9