### PR TITLE
Dockerize services and add compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.gitignore
+docker-compose.yml
+.env

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+BOT_TOKEN=your_bot_token_here
+DB_URL=postgresql://botgrow:secret@db:5432/botgrow

--- a/apps/bot-server/Dockerfile
+++ b/apps/bot-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN corepack enable && pnpm install
+COPY . .
+RUN pnpm build
+CMD ["node", "dist/index.js"]

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN corepack enable && pnpm install
+COPY . .
+RUN pnpm build
+CMD ["node", "dist/index.js"]

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +21,8 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
+    "@types/cors": "^2.8.17",
+    "@types/body-parser": "^1.19.5",
     "@types/node": "^24.2.0",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: botgrow
+      POSTGRES_USER: botgrow
+      POSTGRES_PASSWORD: secret
+  core-api:
+    build: apps/core-api
+    ports:
+      - "4000:4000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+  bot-server:
+    build: apps/bot-server
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    depends_on:
+      - db


### PR DESCRIPTION
## Summary
- add Dockerfiles for core-api and bot-server with pnpm build and node start
- wire up docker-compose with postgres, core-api, and bot-server services
- add shared .env and .dockerignore
- add build/start scripts and type deps for core-api

## Testing
- `pnpm --filter core-api run build`
- `pnpm --filter bot-server run build`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689577fabc248324a377e8845e386ed2