### PR TITLE
Persist Postgres data and move DB config to .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: postgres:15
     ports:
       - "5432:5432"
-    environment:
-      POSTGRES_DB: botgrow
-      POSTGRES_USER: botgrow
-      POSTGRES_PASSWORD: secret
+    env_file:
+      - .env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
   core-api:
     build: apps/core-api
     ports:
@@ -24,3 +24,6 @@ services:
       - .env
     depends_on:
       - db
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- load database credentials from `.env` instead of hardcoding them in docker compose
- persist Postgres data with a named `pgdata` volume
- avoid committing sensitive Postgres variables to `.env`

## Testing
- `pnpm lint` *(fails: sh: 1: turbo: not found)*
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68959c17c48c83249a26162fce8f69a6