### PR TITLE
feat: add Vite React frontend with Tailwind and Zustand

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BotGrow Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "zustand": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.3",
+    "@types/react": "^19.1.9",
+    "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^4.7.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.4",
+    "typescript": "~5.8.3",
+    "vite": "^7.1.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,20 @@
+import Navbar from '@/components/Navbar';
+import Dashboard from '@/pages/Dashboard';
+import Bots from '@/pages/Bots';
+import Settings from '@/pages/Settings';
+import { useAppStore } from '@/store/appStore';
+
+export default function App() {
+  const currentPage = useAppStore((s) => s.currentPage);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <main className="p-4">
+        {currentPage === 'dashboard' && <Dashboard />}
+        {currentPage === 'bots' && <Bots />}
+        {currentPage === 'settings' && <Settings />}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  title?: string;
+  children: ReactNode;
+};
+
+export default function Card({ title, children }: Props) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      {title && <h2 className="text-lg font-semibold mb-2">{title}</h2>}
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,30 @@
+import { useAppStore } from '@/store/appStore';
+
+export default function Navbar() {
+  const { currentPage, setPage } = useAppStore();
+
+  const linkClass = (page: typeof currentPage) =>
+    currentPage === page ? 'font-semibold text-blue-600' : 'text-gray-600';
+
+  return (
+    <nav className="bg-white shadow">
+      <div className="container mx-auto px-4 py-2 flex gap-4">
+        <button
+          className={linkClass('dashboard')}
+          onClick={() => setPage('dashboard')}
+        >
+          Dashboard
+        </button>
+        <button className={linkClass('bots')} onClick={() => setPage('bots')}>
+          Bots
+        </button>
+        <button
+          className={linkClass('settings')}
+          onClick={() => setPage('settings')}
+        >
+          Settings
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+import './styles/index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+import Card from '@/components/Card';
+import { getBots } from '@/shared/api';
+import type { Bot } from '@/shared/types';
+
+export default function Bots() {
+  const [bots, setBots] = useState<Bot[]>([]);
+
+  useEffect(() => {
+    getBots().then(setBots);
+  }, []);
+
+  return (
+    <Card title="Bots">
+      <ul className="list-disc pl-6 space-y-1">
+        {bots.map((b) => (
+          <li key={b.id}>{b.name}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,9 @@
+import Card from '@/components/Card';
+
+export default function Dashboard() {
+  return (
+    <Card title="Dashboard">
+      <p>Welcome to the dashboard.</p>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,9 @@
+import Card from '@/components/Card';
+
+export default function Settings() {
+  return (
+    <Card title="Settings">
+      <p>Settings page content.</p>
+    </Card>
+  );
+}

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,0 +1,5 @@
+import type { Bot } from './types';
+
+export async function getBots(): Promise<Bot[]> {
+  return Promise.resolve([{ id: 1, name: 'Mock Bot' }]);
+}

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -1,0 +1,4 @@
+export interface Bot {
+  id: number;
+  name: string;
+}

--- a/frontend/src/store/appStore.ts
+++ b/frontend/src/store/appStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type AppState = {
+  currentPage: 'dashboard' | 'bots' | 'settings';
+  setPage: (p: AppState['currentPage']) => void;
+};
+
+export const useAppStore = create<AppState>((set) => ({
+  currentPage: 'dashboard',
+  setPage: (p) => set({ currentPage: p }),
+}));

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "node"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold frontend React app with Vite + TS
- add Tailwind CSS and Zustand state store
- provide sample pages and components with @ path alias

## Testing
- `pnpm --dir frontend --ignore-workspace run build`

------
https://chatgpt.com/codex/tasks/task_e_6899513d012c832492416c57f38eed92