### PR TITLE
feat(db): add prisma user service

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.5.2",
   "dependencies": {
+    "@botgrow/db": "workspace:*",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0"

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import { userService } from '@botgrow/db';
 
 dotenv.config();
 
@@ -18,6 +19,23 @@ app.post('/contacts', (req: Request, res: Response) => {
   const { userId, username, lang } = req.body as ContactBody;
   console.log({ userId, username, lang });
   res.sendStatus(200);
+});
+
+app.post('/auth/telegram', async (req: Request, res: Response) => {
+  const telegramUser = req.body;
+  try {
+    const user = await userService.createOrUpdateByTelegram({
+      telegramId: telegramUser.id,
+      username: telegramUser.username,
+      firstName: telegramUser.first_name,
+      lastName: telegramUser.last_name,
+      photoUrl: telegramUser.photo_url,
+    });
+    res.json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to persist user' });
+  }
 });
 
 const PORT = 4000;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "db:migrate": "pnpm --filter @botgrow/db exec prisma migrate dev"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.38.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,11 @@
 {
   "name": "@botgrow/db",
   "version": "1.0.0",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "dependencies": {
+    "@prisma/client": "^6.14.0"
+  },
+  "devDependencies": {
+    "prisma": "^6.14.0"
+  }
 }

--- a/packages/db/prisma/migrations/20240101000000_init/migration.sql
+++ b/packages/db/prisma/migrations/20240101000000_init/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "telegramId" INTEGER NOT NULL,
+    "username" TEXT,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT,
+    "photoUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_telegramId_key" ON "User"("telegramId");

--- a/packages/db/prisma/migrations/migration_lock.toml
+++ b/packages/db/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id          String   @id @default(uuid())
+  telegramId  Int      @unique
+  username    String?
+  firstName   String
+  lastName    String?
+  photoUrl    String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,2 +1,3 @@
 export * from './memory';
 export * from './types';
+export * from './services/UserService';

--- a/packages/db/src/prisma.ts
+++ b/packages/db/src/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/packages/db/src/repositories/BaseRepository.ts
+++ b/packages/db/src/repositories/BaseRepository.ts
@@ -1,0 +1,31 @@
+export class BaseRepository<T, Key extends keyof T> {
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected readonly model: any,
+    protected readonly idField: Key = 'id' as Key,
+  ) {}
+
+  create(data: Omit<T, Key>) {
+    return this.model.create({ data });
+  }
+
+  findById(id: T[Key]) {
+    return this.model.findUnique({ where: { [this.idField]: id } });
+  }
+
+  findOne(where: Partial<T>) {
+    return this.model.findFirst({ where });
+  }
+
+  findMany(where?: Partial<T>) {
+    return this.model.findMany({ where });
+  }
+
+  update(id: T[Key], data: Partial<T>) {
+    return this.model.update({ where: { [this.idField]: id }, data });
+  }
+
+  delete(id: T[Key]) {
+    return this.model.delete({ where: { [this.idField]: id } });
+  }
+}

--- a/packages/db/src/services/UserService.ts
+++ b/packages/db/src/services/UserService.ts
@@ -1,0 +1,30 @@
+import { User } from '@prisma/client';
+
+import { prisma } from '../prisma';
+import { BaseRepository } from '../repositories/BaseRepository';
+
+export class UserService extends BaseRepository<User, 'id'> {
+  constructor() {
+    super(prisma.user, 'id');
+  }
+
+  findByTelegramId(telegramId: number) {
+    return this.model.findUnique({ where: { telegramId } });
+  }
+
+  async createOrUpdateByTelegram(data: {
+    telegramId: number;
+    username?: string;
+    firstName: string;
+    lastName?: string;
+    photoUrl?: string;
+  }) {
+    return this.model.upsert({
+      where: { telegramId: data.telegramId },
+      update: data,
+      create: data,
+    });
+  }
+}
+
+export const userService = new UserService();


### PR DESCRIPTION
## Summary
- set up Prisma with Postgres datasource and user model
- add generic BaseRepository and UserService with Telegram helpers
- expose userService and integrate into core-api login route
- add migration and script for db:migrate

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*
- `pnpm --filter @botgrow/db exec prisma generate` *(fails: Failed to fetch engine file - 403)*
- `pnpm db:migrate` *(fails: Failed to fetch engine file - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a039b91be483249302809c4cbd00cc