### PR TITLE
feat: add Telegram auth and dev login

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsx src/utils/telegram.test.ts",
     "dev": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"
@@ -17,11 +17,14 @@
     "@botgrow/db": "workspace:*",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.2.0",
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -1,13 +1,16 @@
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import { userService } from '@botgrow/db';
+
+import authRouter from './routes/auth';
 
 dotenv.config();
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+app.use('/auth', authRouter);
 
 interface ContactBody {
   userId: string;
@@ -19,23 +22,6 @@ app.post('/contacts', (req: Request, res: Response) => {
   const { userId, username, lang } = req.body as ContactBody;
   console.log({ userId, username, lang });
   res.sendStatus(200);
-});
-
-app.post('/auth/telegram', async (req: Request, res: Response) => {
-  const telegramUser = req.body;
-  try {
-    const user = await userService.createOrUpdateByTelegram({
-      telegramId: telegramUser.id,
-      username: telegramUser.username,
-      firstName: telegramUser.first_name,
-      lastName: telegramUser.last_name,
-      photoUrl: telegramUser.photo_url,
-    });
-    res.json(user);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to persist user' });
-  }
 });
 
 const PORT = 4000;

--- a/apps/core-api/src/routes/auth.ts
+++ b/apps/core-api/src/routes/auth.ts
@@ -1,0 +1,78 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { userService } from '@botgrow/db';
+
+import {
+  TelegramAuthUser,
+  verifyTelegramAuth,
+  toUserUpsert,
+} from '../utils/telegram';
+import { signJwt } from '../utils/jwt';
+
+const router = Router();
+
+const telegramSchema = z.object({
+  id: z.number(),
+  first_name: z.string(),
+  last_name: z.string().optional(),
+  username: z.string().optional(),
+  photo_url: z.string().optional(),
+  auth_date: z.number(),
+  hash: z.string(),
+});
+
+router.post('/telegram', async (req, res) => {
+  let body: TelegramAuthUser;
+  try {
+    body = telegramSchema.parse(req.body);
+  } catch {
+    return res.status(400).json({ error: 'bad_request' });
+  }
+
+  const botToken = process.env.AUTH_TELEGRAM_BOT_TOKEN;
+  if (!botToken || !verifyTelegramAuth(body, botToken)) {
+    return res.status(401).json({ error: 'invalid_signature' });
+  }
+
+  try {
+    const user = await userService.createOrUpdateByTelegram(toUserUpsert(body));
+    const token = signJwt(
+      { sub: user.id, tid: user.telegramId, username: user.username },
+      process.env.JWT_SECRET!,
+      process.env.JWT_EXPIRES || '7d',
+    );
+    res.json({ token, user });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+router.post('/dev-login', async (_req, res) => {
+  const devMode =
+    process.env.DEV_MODE === 'true' || process.env.NODE_ENV !== 'production';
+  if (!devMode) return res.status(403).json({ error: 'forbidden' });
+
+  const dev = {
+    telegramId: Number(process.env.DEV_USER_TELEGRAM_ID || 999999),
+    username: process.env.DEV_USER_USERNAME || 'devuser',
+    firstName: process.env.DEV_USER_FIRST_NAME || 'Dev',
+    lastName: process.env.DEV_USER_LAST_NAME || 'User',
+    photoUrl: process.env.DEV_USER_PHOTO_URL,
+  };
+
+  try {
+    const user = await userService.createOrUpdateByTelegram(dev);
+    const token = signJwt(
+      { sub: user.id, tid: user.telegramId, username: user.username },
+      process.env.JWT_SECRET!,
+      process.env.JWT_EXPIRES || '7d',
+    );
+    res.json({ token, user });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+export default router;

--- a/apps/core-api/src/utils/jwt.ts
+++ b/apps/core-api/src/utils/jwt.ts
@@ -1,0 +1,17 @@
+import jwt from 'jsonwebtoken';
+
+export function signJwt(
+  payload: object,
+  secret: string,
+  expiresIn: string,
+): string {
+  return jwt.sign(
+    payload,
+    secret as jwt.Secret,
+    { expiresIn } as jwt.SignOptions,
+  );
+}
+
+export function verifyJwt<T>(token: string, secret: string): T {
+  return jwt.verify(token, secret as jwt.Secret) as T;
+}

--- a/apps/core-api/src/utils/telegram.test.ts
+++ b/apps/core-api/src/utils/telegram.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import crypto from 'crypto';
+
+import {
+  buildCheckString,
+  verifyTelegramAuth,
+  TelegramAuthUser,
+} from './telegram';
+
+const botToken = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
+const base: TelegramAuthUser = {
+  id: 1,
+  first_name: 'Test',
+  auth_date: Math.floor(Date.now() / 1000),
+  hash: '',
+};
+const checkString = buildCheckString(base);
+const secret = crypto.createHash('sha256').update(botToken).digest();
+const hash = crypto
+  .createHmac('sha256', secret)
+  .update(checkString)
+  .digest('hex');
+const payload: TelegramAuthUser = { ...base, hash };
+
+assert.ok(verifyTelegramAuth(payload, botToken));
+
+payload.hash = 'deadbeef';
+assert.ok(!verifyTelegramAuth(payload, botToken));
+
+console.log('telegram auth tests passed');

--- a/apps/core-api/src/utils/telegram.ts
+++ b/apps/core-api/src/utils/telegram.ts
@@ -1,0 +1,50 @@
+import crypto from 'crypto';
+
+export type TelegramAuthUser = {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  photo_url?: string;
+  auth_date: number;
+  hash: string;
+};
+
+export function buildCheckString(payload: TelegramAuthUser): string {
+  return Object.entries(payload)
+    .filter(([k]) => k !== 'hash')
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+}
+
+export function verifyTelegramAuth(
+  payload: TelegramAuthUser,
+  botToken: string,
+  maxAgeSec = 600,
+): boolean {
+  const checkString = buildCheckString(payload);
+  const secret = crypto.createHash('sha256').update(botToken).digest();
+  const hmac = crypto
+    .createHmac('sha256', secret)
+    .update(checkString)
+    .digest('hex');
+  const hashBuf = Buffer.from(payload.hash, 'hex');
+  const hmacBuf = Buffer.from(hmac, 'hex');
+  const isValidHash =
+    hashBuf.length === hmacBuf.length &&
+    crypto.timingSafeEqual(hashBuf, hmacBuf);
+  const now = Math.floor(Date.now() / 1000);
+  const isFresh = now - payload.auth_date <= maxAgeSec;
+  return isValidHash && isFresh;
+}
+
+export function toUserUpsert(payload: TelegramAuthUser) {
+  return {
+    telegramId: payload.id,
+    username: payload.username,
+    firstName: payload.first_name,
+    lastName: payload.last_name,
+    photoUrl: payload.photo_url,
+  };
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/store/auth';
-import { authTelegram } from '@/shared/api';
+import { authTelegram, devLogin } from '@/shared/api';
 
 type TelegramAuthUser = {
   id: number;
@@ -23,6 +23,8 @@ export default function Login() {
   const nav = useNavigate();
   const login = useAuth((s) => s.login);
   const widgetRef = useRef<HTMLDivElement>(null);
+  const showDev =
+    import.meta.env.DEV && import.meta.env.VITE_ENABLE_DEV_LOGIN === 'true';
 
   // global callback: called by Telegram widget
   (window as TGWindow).onTelegramAuth = async (user: TelegramAuthUser) => {
@@ -59,6 +61,24 @@ export default function Login() {
       <div className="p-8 rounded-2xl shadow bg-white space-y-4 text-center">
         <h1 className="text-2xl font-semibold">Sign in to BotGrow</h1>
         <div ref={widgetRef} className="flex justify-center" />
+        {showDev && (
+          <button
+            type="button"
+            className="w-full bg-gray-200 text-gray-700 py-2 rounded"
+            onClick={async () => {
+              try {
+                const res = await devLogin();
+                useAuth.getState().login(res.token, res.user);
+                nav('/', { replace: true });
+              } catch (e) {
+                console.error('Dev login failed', e);
+                alert('Dev login failed');
+              }
+            }}
+          >
+            Login as Demo User
+          </button>
+        )}
         <p className="text-sm text-gray-500">
           Login with your Telegram account to continue.
         </p>

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
-import { useAuth } from '@/store/auth';
+
 import type { Bot } from './types';
+
+import { useAuth } from '@/store/auth';
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_CORE_API_URL,
@@ -13,9 +15,14 @@ api.interceptors.request.use((config) => {
 });
 
 // POST /auth/telegram
-export async function authTelegram(payload: any) {
+export async function authTelegram(payload: unknown) {
   const { data } = await api.post('/auth/telegram', payload);
-  return data as { token: string; user: any };
+  return data as { token: string; user: unknown };
+}
+
+export async function devLogin() {
+  const { data } = await api.post('/auth/dev-login');
+  return data as { token: string; user: unknown };
 }
 
 export async function getBots(): Promise<Bot[]> {


### PR DESCRIPTION
## Summary
- verify Telegram login payloads and generate JWTs
- add dev-login route and matching frontend button
- expose JWT helpers and Telegram signature utilities

## Testing
- `pnpm --filter core-api test`
- `pnpm --filter frontend build`
- `pnpm --filter core-api build` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68a745c5f95083248221f51d9c6c4e1d