### PR TITLE
feat: add bots crud with encryption

### DIFF
--- a/apps/core-api/src/config/index.ts
+++ b/apps/core-api/src/config/index.ts
@@ -7,6 +7,7 @@ export const config = {
   jwtSecret: process.env.JWT_SECRET!,
   jwtExpires: process.env.JWT_EXPIRES || '7d',
   telegramBotToken: process.env.AUTH_TELEGRAM_BOT_TOKEN,
+  encryptionKey: process.env.ENCRYPTION_KEY!,
   devMode:
     process.env.DEV_MODE === 'true' || process.env.NODE_ENV !== 'production',
   devUser: {

--- a/apps/core-api/src/lib/crypto.ts
+++ b/apps/core-api/src/lib/crypto.ts
@@ -1,0 +1,44 @@
+import crypto from 'crypto';
+
+import { config } from '../config';
+
+const ENC_ALGO = 'aes-256-gcm';
+
+function getKey(): Buffer {
+  const key = config.encryptionKey;
+  return Buffer.from(key, key.length === 64 ? 'hex' : 'base64');
+}
+
+export function encryptToken(plain: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ENC_ALGO, getKey(), iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plain, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decryptToken(payload: string): string {
+  const buf = Buffer.from(payload, 'base64');
+  const iv = buf.subarray(0, 12);
+  const tag = buf.subarray(12, 28);
+  const text = buf.subarray(28);
+  const decipher = crypto.createDecipheriv(ENC_ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+export function maskToken(plain: string): string {
+  return plain.replace(/.(?=.{4})/g, '*');
+}
+
+export function maskTokenFromLast4(last4: string): string {
+  return `********${last4}`;
+}
+
+export function hashToken(plain: string): string {
+  return crypto.createHash('sha256').update(plain).digest('hex');
+}

--- a/apps/core-api/src/middlewares/authGuard.ts
+++ b/apps/core-api/src/middlewares/authGuard.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+
+import { verifyJwt } from '../lib/jwt';
+import { ApiError } from '../lib/errors';
+import { config } from '../config';
+
+export function authGuard(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return next(new ApiError(401, 'unauthorized', 'Missing token'));
+  }
+  const token = header.slice(7);
+  try {
+    const payload = verifyJwt<{ sub: string; tid?: number; username?: string }>(
+      token,
+      config.jwtSecret,
+    );
+    req.user = {
+      id: payload.sub,
+      telegramId: payload.tid,
+      username: payload.username,
+    };
+    next();
+  } catch {
+    next(new ApiError(401, 'unauthorized', 'Invalid token'));
+  }
+}
+
+export default authGuard;

--- a/apps/core-api/src/modules/bots/bots.controller.ts
+++ b/apps/core-api/src/modules/bots/bots.controller.ts
@@ -1,0 +1,67 @@
+import type { Request, Response, NextFunction } from 'express';
+
+import { botsService } from './bots.service';
+
+export async function listBots(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const bots = await botsService.listBots(req.user!.id);
+    res.json({ ok: true, data: { bots } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createBot(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const result = await botsService.createBot(req.user!.id, req.body);
+    res.json({ ok: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getBot(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = Number(req.params.id);
+    const result = await botsService.getBot(req.user!.id, id);
+    res.json({ ok: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateBot(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const id = Number(req.params.id);
+    const result = await botsService.updateBot(req.user!.id, id, req.body);
+    res.json({ ok: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteBot(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const id = Number(req.params.id);
+    await botsService.deleteBot(req.user!.id, id);
+    res.json({ ok: true, data: {} });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/core-api/src/modules/bots/bots.mapper.ts
+++ b/apps/core-api/src/modules/bots/bots.mapper.ts
@@ -1,0 +1,39 @@
+import { Bot } from '@prisma/client';
+
+import { maskToken, maskTokenFromLast4 } from '../../lib/crypto';
+
+export type BotDTO = {
+  id: number;
+  name: string;
+  description?: string | null;
+  photoUrl?: string | null;
+  tokenMasked: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function toBotDTO(
+  bot: Bot,
+  plainToken?: string,
+): {
+  bot: BotDTO;
+  plainBotToken?: string;
+} {
+  const tokenMasked = plainToken
+    ? maskToken(plainToken)
+    : maskTokenFromLast4(bot.tokenLast4);
+
+  const dto: BotDTO = {
+    id: bot.id,
+    name: bot.name,
+    description: bot.description,
+    photoUrl: bot.photoUrl,
+    tokenMasked,
+    createdAt: bot.createdAt.toISOString(),
+    updatedAt: bot.updatedAt.toISOString(),
+  };
+
+  const res: { bot: BotDTO; plainBotToken?: string } = { bot: dto };
+  if (plainToken) res.plainBotToken = plainToken;
+  return res;
+}

--- a/apps/core-api/src/modules/bots/bots.routes.ts
+++ b/apps/core-api/src/modules/bots/bots.routes.ts
@@ -1,0 +1,58 @@
+import {
+  Router,
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
+import type { ZodSchema } from 'zod';
+
+import validate from '../../middlewares/validate';
+import { authGuard } from '../../middlewares/authGuard';
+import { ApiError } from '../../lib/errors';
+
+import {
+  createBotSchema,
+  updateBotSchema,
+  idParamSchema,
+} from './bots.validators';
+import {
+  listBots,
+  createBot,
+  getBot,
+  updateBot,
+  deleteBot,
+} from './bots.controller';
+
+const validateParams =
+  (schema: ZodSchema) => (req: Request, _res: Response, next: NextFunction) => {
+    const r = schema.safeParse(req.params);
+    if (!r.success) {
+      return next(
+        new ApiError(
+          400,
+          'bad_request',
+          'Invalid request params',
+          r.error.flatten(),
+        ),
+      );
+    }
+    req.params = r.data;
+    next();
+  };
+
+const router = Router();
+
+router.use(authGuard);
+
+router.get('/', listBots);
+router.post('/', validate(createBotSchema), createBot);
+router.get('/:id', validateParams(idParamSchema), getBot);
+router.put(
+  '/:id',
+  validateParams(idParamSchema),
+  validate(updateBotSchema),
+  updateBot,
+);
+router.delete('/:id', validateParams(idParamSchema), deleteBot);
+
+export default router;

--- a/apps/core-api/src/modules/bots/bots.service.ts
+++ b/apps/core-api/src/modules/bots/bots.service.ts
@@ -1,0 +1,79 @@
+import { botService } from '@botgrow/db';
+
+import { ApiError } from '../../lib/errors';
+import { encryptToken, hashToken } from '../../lib/crypto';
+
+import { toBotDTO } from './bots.mapper';
+
+export class BotsService {
+  async listBots(userId: string) {
+    const bots = await botService.findAllByUser(userId);
+    return bots.map((b) => toBotDTO(b).bot);
+  }
+
+  async createBot(
+    userId: string,
+    data: {
+      name: string;
+      description?: string | null;
+      photoUrl?: string | null;
+      botToken: string;
+    },
+  ) {
+    const encryptedToken = encryptToken(data.botToken);
+    const tokenHash = hashToken(data.botToken);
+    const tokenLast4 = data.botToken.slice(-4);
+    const bot = await botService.create({
+      userId,
+      name: data.name,
+      description: data.description,
+      photoUrl: data.photoUrl,
+      encryptedToken,
+      tokenHash,
+      tokenLast4,
+    });
+    return toBotDTO(bot, data.botToken);
+  }
+
+  async getBot(userId: string, id: number) {
+    const bot = await botService.findByIdForUser(id, userId);
+    if (!bot) throw new ApiError(404, 'not_found', 'Bot not found');
+    return toBotDTO(bot);
+  }
+
+  async updateBot(
+    userId: string,
+    id: number,
+    patch: {
+      name?: string;
+      description?: string | null;
+      photoUrl?: string | null;
+      botToken?: string;
+    },
+  ) {
+    const existing = await botService.findByIdForUser(id, userId);
+    if (!existing) throw new ApiError(404, 'not_found', 'Bot not found');
+    const data: Record<string, unknown> = {};
+    let plain: string | undefined;
+    if (patch.name !== undefined) data.name = patch.name;
+    if (patch.description !== undefined) data.description = patch.description;
+    if (patch.photoUrl !== undefined) data.photoUrl = patch.photoUrl;
+    if (patch.botToken) {
+      plain = patch.botToken;
+      data.encryptedToken = encryptToken(patch.botToken);
+      data.tokenHash = hashToken(patch.botToken);
+      data.tokenLast4 = patch.botToken.slice(-4);
+    }
+    const updated = await botService.updateForUser(id, userId, data);
+    if (!updated) throw new ApiError(404, 'not_found', 'Bot not found');
+    return toBotDTO(updated, plain);
+  }
+
+  async deleteBot(userId: string, id: number) {
+    const ok = await botService.deleteForUser(id, userId);
+    if (!ok) throw new ApiError(404, 'not_found', 'Bot not found');
+  }
+}
+
+export const botsService = new BotsService();
+export default botsService;

--- a/apps/core-api/src/modules/bots/bots.validators.ts
+++ b/apps/core-api/src/modules/bots/bots.validators.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const createBotSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(1000).optional(),
+  photoUrl: z.string().url().optional(),
+  botToken: z.string().min(20),
+});
+
+export const updateBotSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    description: z.string().max(1000).optional(),
+    photoUrl: z.string().url().optional(),
+    botToken: z.string().min(20).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export const idParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});

--- a/apps/core-api/src/routes/index.ts
+++ b/apps/core-api/src/routes/index.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 
 import authRoutes from '../modules/auth/auth.routes';
+import botsRoutes from '../modules/bots/bots.routes';
 
 const router = Router();
 
 router.use('/auth', authRoutes);
+router.use('/bots', botsRoutes);
 
 export default router;

--- a/apps/core-api/src/types/express.d.ts
+++ b/apps/core-api/src/types/express.d.ts
@@ -1,0 +1,10 @@
+declare namespace Express {
+  interface UserPayload {
+    id: string;
+    telegramId?: number;
+    username?: string;
+  }
+  interface Request {
+    user?: UserPayload;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,16 @@
 import { StrictMode, type ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+} from 'react-router-dom';
+
 import App from './App';
+
 import Dashboard from '@/pages/Dashboard';
 import Bots from '@/pages/Bots';
+import BotEdit from '@/pages/BotEdit';
 import Settings from '@/pages/Settings';
 import Login from '@/pages/Login';
 import { useAuth } from '@/store/auth';
@@ -25,6 +32,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Dashboard /> },
       { path: 'bots', element: <Bots /> },
+      { path: 'bots/:id', element: <BotEdit /> },
       { path: 'settings', element: <Settings /> },
     ],
   },

--- a/frontend/src/pages/BotEdit.tsx
+++ b/frontend/src/pages/BotEdit.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState, ChangeEvent, FormEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import Card from '@/components/Card';
+import { getBot, createBot, updateBot, deleteBot } from '@/shared/api';
+import type { Bot } from '@/shared/types';
+
+export default function BotEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const isNew = id === 'new';
+
+  const [bot, setBot] = useState<Bot | null>(null);
+  const [plainToken, setPlainToken] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    photoUrl: '',
+    botToken: '',
+  });
+
+  useEffect(() => {
+    if (!isNew && id) {
+      getBot(Number(id)).then((b) => {
+        setBot(b);
+        setForm({
+          name: b.name,
+          description: b.description || '',
+          photoUrl: b.photoUrl || '',
+          botToken: '',
+        });
+      });
+    }
+  }, [id, isNew]);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isNew) {
+        const res = await createBot({
+          name: form.name,
+          description: form.description || undefined,
+          photoUrl: form.photoUrl || undefined,
+          botToken: form.botToken,
+        });
+        setPlainToken(res.plainBotToken || null);
+        setBot(res.bot);
+        navigate(`/bots/${res.bot.id}`, { replace: true });
+      } else if (id) {
+        const res = await updateBot(Number(id), {
+          name: form.name,
+          description: form.description || undefined,
+          photoUrl: form.photoUrl || undefined,
+          botToken: form.botToken || undefined,
+        });
+        setPlainToken(res.plainBotToken || null);
+        setBot(res.bot);
+        setForm({ ...form, botToken: '' });
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Failed to save');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!id || isNew) return;
+    if (!confirm('Delete this bot?')) return;
+    await deleteBot(Number(id));
+    navigate('/bots');
+  };
+
+  return (
+    <Card title={isNew ? 'Create Bot' : 'Edit Bot'}>
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div>
+          <label className="block mb-1">Name *</label>
+          <input
+            name="name"
+            className="border p-2 w-full"
+            value={form.name}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <textarea
+            name="description"
+            className="border p-2 w-full"
+            value={form.description}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Photo URL</label>
+          <input
+            name="photoUrl"
+            className="border p-2 w-full"
+            value={form.photoUrl}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">
+            Bot Token {isNew ? '*' : ''}{' '}
+            <span className="text-xs text-gray-500">
+              (we won’t show it again)
+            </span>
+          </label>
+          <input
+            name="botToken"
+            className="border p-2 w-full font-mono"
+            value={form.botToken}
+            onChange={handleChange}
+            placeholder={isNew ? '' : bot?.tokenMasked}
+          />
+        </div>
+        {plainToken && (
+          <div className="bg-yellow-100 p-2 rounded text-sm">
+            Plain token: <span className="font-mono">{plainToken}</span>
+            <button
+              type="button"
+              className="ml-2 text-blue-600"
+              onClick={() => navigator.clipboard.writeText(plainToken)}
+            >
+              Copy
+            </button>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="bg-green-500 text-white px-4 py-1 rounded"
+          >
+            Save
+          </button>
+          {!isNew && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="bg-red-500 text-white px-4 py-1 rounded"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,23 +1,67 @@
 import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 
 import Card from '@/components/Card';
-import { getBots } from '@/shared/api';
+import { listBots, deleteBot } from '@/shared/api';
 import type { Bot } from '@/shared/types';
 
 export default function Bots() {
   const [bots, setBots] = useState<Bot[]>([]);
+  const navigate = useNavigate();
+
+  const load = () => listBots().then(setBots);
 
   useEffect(() => {
-    getBots().then(setBots);
+    load();
   }, []);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Delete this bot?')) return;
+    await deleteBot(id);
+    load();
+  };
 
   return (
     <Card title="Bots">
-      <ul className="list-disc pl-6 space-y-1">
-        {bots.map((b) => (
-          <li key={b.id}>{b.name}</li>
-        ))}
-      </ul>
+      <div className="mb-4">
+        <Link
+          to="/bots/new"
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+        >
+          Create Bot
+        </Link>
+      </div>
+      <table className="min-w-full text-left">
+        <thead>
+          <tr>
+            <th className="py-2">Name</th>
+            <th className="py-2">Token</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {bots.map((b) => (
+            <tr key={b.id} className="border-t">
+              <td className="py-2">{b.name}</td>
+              <td className="py-2 font-mono">{b.tokenMasked}</td>
+              <td className="py-2 space-x-2">
+                <button
+                  className="text-blue-600"
+                  onClick={() => navigate(`/bots/${b.id}`)}
+                >
+                  Open
+                </button>
+                <button
+                  className="text-red-600"
+                  onClick={() => handleDelete(b.id)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </Card>
   );
 }

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 
-import type { Bot } from './types';
+import type {
+  Bot,
+  BotWithToken,
+  CreateBotInput,
+  UpdateBotInput,
+} from './types';
 
 import type { TGUser } from '@/store/auth';
 import { useAuth } from '@/store/auth';
@@ -27,7 +32,31 @@ export async function devLogin() {
   return data as { token: string; user: TGUser };
 }
 
-export async function getBots(): Promise<Bot[]> {
+export async function listBots(): Promise<Bot[]> {
   const { data } = await api.get('/bots');
-  return data as Bot[];
+  return data.data.bots as Bot[];
+}
+
+export async function getBot(id: number): Promise<Bot> {
+  const { data } = await api.get(`/bots/${id}`);
+  return data.data.bot as Bot;
+}
+
+export async function createBot(
+  payload: CreateBotInput,
+): Promise<BotWithToken> {
+  const { data } = await api.post('/bots', payload);
+  return data.data as BotWithToken;
+}
+
+export async function updateBot(
+  id: number,
+  payload: UpdateBotInput,
+): Promise<BotWithToken> {
+  const { data } = await api.put(`/bots/${id}`, payload);
+  return data.data as BotWithToken;
+}
+
+export async function deleteBot(id: number): Promise<void> {
+  await api.delete(`/bots/${id}`);
 }

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -1,4 +1,28 @@
 export interface Bot {
   id: number;
   name: string;
+  description?: string | null;
+  photoUrl?: string | null;
+  tokenMasked: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BotWithToken {
+  bot: Bot;
+  plainBotToken?: string;
+}
+
+export interface CreateBotInput {
+  name: string;
+  description?: string | null;
+  photoUrl?: string | null;
+  botToken: string;
+}
+
+export interface UpdateBotInput {
+  name?: string;
+  description?: string | null;
+  photoUrl?: string | null;
+  botToken?: string;
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,7 +16,10 @@
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
     "postinstall": "prisma generate",
-    "prisma:generate": "prisma generate"
+    "prisma:generate": "prisma generate",
+    "migrate:dev": "prisma migrate dev",
+    "migrate:deploy": "prisma migrate deploy",
+    "generate": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.14.0"

--- a/packages/db/prisma/migrations/20250910120000_add_bot/migration.sql
+++ b/packages/db/prisma/migrations/20250910120000_add_bot/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Bot" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "photoUrl" TEXT,
+    "encryptedToken" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "tokenLast4" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Bot_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Bot_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Bot_userId_idx" ON "Bot"("userId");
+-- CreateIndex
+CREATE INDEX "Bot_tokenHash_idx" ON "Bot"("tokenHash");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -17,3 +17,21 @@ model User {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+model Bot {
+  id             Int      @id @default(autoincrement())
+  userId         String
+  name           String
+  description    String?  @db.Text
+  photoUrl       String?
+  encryptedToken String
+  tokenHash      String
+  tokenLast4     String   @default("")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([tokenHash])
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
 export * from './memory';
 export * from './types';
 export * from './services/UserService';
+export * from './services/botService';

--- a/packages/db/src/services/botService.ts
+++ b/packages/db/src/services/botService.ts
@@ -1,0 +1,50 @@
+import { Bot } from '@prisma/client';
+
+import { prisma } from '../prisma';
+
+export const botService = {
+  create(data: {
+    userId: string;
+    name: string;
+    description?: string | null;
+    photoUrl?: string | null;
+    encryptedToken: string;
+    tokenHash: string;
+    tokenLast4?: string;
+  }): Promise<Bot> {
+    return prisma.bot.create({ data });
+  },
+
+  findAllByUser(userId: string): Promise<Bot[]> {
+    return prisma.bot.findMany({ where: { userId }, orderBy: { id: 'asc' } });
+  },
+
+  findByIdForUser(id: number, userId: string): Promise<Bot | null> {
+    return prisma.bot.findFirst({ where: { id, userId } });
+  },
+
+  async updateForUser(
+    id: number,
+    userId: string,
+    data: Partial<
+      Pick<
+        Bot,
+        | 'name'
+        | 'description'
+        | 'photoUrl'
+        | 'encryptedToken'
+        | 'tokenHash'
+        | 'tokenLast4'
+      >
+    >,
+  ): Promise<Bot | null> {
+    const res = await prisma.bot.updateMany({ where: { id, userId }, data });
+    if (!res.count) return null;
+    return prisma.bot.findUnique({ where: { id } });
+  },
+
+  async deleteForUser(id: number, userId: string): Promise<boolean> {
+    const res = await prisma.bot.deleteMany({ where: { id, userId } });
+    return res.count > 0;
+  },
+};


### PR DESCRIPTION
## Summary
- add Bot prisma model and service
- implement encrypted bot CRUD in core-api
- build frontend pages and api for managing bots

## Testing
- `pnpm -F @botgrow/db build` *(fails: Cannot find module '@prisma/client')*
- `pnpm -F @botgrow/db install` *(fails: Failed to fetch prisma engine binaries)*
- `pnpm -F @botgrow/core-api build` *(fails: missing modules like express and zod)*
- `pnpm -F frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1ac98a0c8324b287e84f943fccf4