### PR TITLE
feat: add bot connect and disconnect

### DIFF
--- a/apps/bot-server/src/index.ts
+++ b/apps/bot-server/src/index.ts
@@ -1,9 +1,9 @@
 import dotenv from 'dotenv';
-dotenv.config();
-
 import express from 'express';
 import { Telegraf } from 'telegraf';
 import { addBot, getBotConfig } from '@botgrow/db';
+
+dotenv.config();
 
 addBot('testbot1', {
   token: process.env.BOT_TOKEN as string,
@@ -17,6 +17,11 @@ const app = express();
 app.use(express.json());
 
 app.post('/bot/:botId/webhook', async (req, res) => {
+  const secret = req.get('x-telegram-bot-api-secret-token');
+  if (secret !== process.env.WEBHOOK_SECRET) {
+    return res.status(401).send('Invalid webhook secret');
+  }
+
   const { botId } = req.params;
   const config = getBotConfig(botId);
 

--- a/apps/core-api/src/config/index.ts
+++ b/apps/core-api/src/config/index.ts
@@ -8,6 +8,9 @@ export const config = {
   jwtExpires: process.env.JWT_EXPIRES || '7d',
   telegramBotToken: process.env.AUTH_TELEGRAM_BOT_TOKEN,
   encryptionKey: process.env.ENCRYPTION_KEY!,
+  appBaseUrlBotServer: process.env.APP_BASE_URL_BOTSERVER!,
+  webhookSecret: process.env.WEBHOOK_SECRET!,
+  telegramApiBase: process.env.TELEGRAM_API_BASE || 'https://api.telegram.org',
   devMode:
     process.env.DEV_MODE === 'true' || process.env.NODE_ENV !== 'production',
   devUser: {

--- a/apps/core-api/src/modules/bots/bots.controller.ts
+++ b/apps/core-api/src/modules/bots/bots.controller.ts
@@ -65,3 +65,31 @@ export async function deleteBot(
     next(err);
   }
 }
+
+export async function connectBot(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const id = req.params.id;
+    const result = await botsService.connectBot(req.user!.id, id);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function disconnectBot(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const id = req.params.id;
+    const result = await botsService.disconnectBot(req.user!.id, id);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/core-api/src/modules/bots/bots.mapper.ts
+++ b/apps/core-api/src/modules/bots/bots.mapper.ts
@@ -1,4 +1,10 @@
-import { Bot } from '@prisma/client';
+import { Bot as PrismaBot } from '@prisma/client';
+
+type Bot = PrismaBot & {
+  status: string;
+  webhookUrl: string | null;
+  lastError: string | null;
+};
 
 import { maskToken, maskTokenFromLast4 } from '../../lib/crypto';
 
@@ -8,6 +14,9 @@ export type BotDTO = {
   description?: string | null;
   photoUrl?: string | null;
   tokenMasked: string;
+  status: string;
+  webhookUrl?: string | null;
+  lastError?: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -29,6 +38,9 @@ export function toBotDTO(
     description: bot.description,
     photoUrl: bot.photoUrl,
     tokenMasked,
+    status: bot.status,
+    webhookUrl: bot.webhookUrl,
+    lastError: bot.lastError,
     createdAt: bot.createdAt.toISOString(),
     updatedAt: bot.updatedAt.toISOString(),
   };

--- a/apps/core-api/src/modules/bots/bots.routes.ts
+++ b/apps/core-api/src/modules/bots/bots.routes.ts
@@ -21,6 +21,8 @@ import {
   getBot,
   updateBot,
   deleteBot,
+  connectBot,
+  disconnectBot,
 } from './bots.controller';
 
 const validateParams =
@@ -54,5 +56,7 @@ router.put(
   updateBot,
 );
 router.delete('/:id', validateParams(idParamSchema), deleteBot);
+router.post('/:id/connect', validateParams(idParamSchema), connectBot);
+router.post('/:id/disconnect', validateParams(idParamSchema), disconnectBot);
 
 export default router;

--- a/apps/core-api/src/modules/bots/bots.service.ts
+++ b/apps/core-api/src/modules/bots/bots.service.ts
@@ -1,9 +1,21 @@
 import { botService } from '@botgrow/db';
 
 import { ApiError } from '../../lib/errors';
-import { encryptToken, hashToken } from '../../lib/crypto';
+import { decryptToken, encryptToken, hashToken } from '../../lib/crypto';
+import { config } from '../../config';
 
 import { toBotDTO } from './bots.mapper';
+
+function stripTrailingSlash(u: string): string {
+  let s = u;
+  while (s.endsWith('/')) s = s.slice(0, -1);
+  return s;
+}
+
+type TelegramApiResponse = {
+  ok?: boolean;
+  description?: string;
+};
 
 export class BotsService {
   async listBots(userId: string) {
@@ -72,6 +84,95 @@ export class BotsService {
   async deleteBot(userId: string, id: string) {
     const ok = await botService.deleteForUser(id, userId);
     if (!ok) throw new ApiError(404, 'not_found', 'Bot not found');
+  }
+
+  async connectBot(userId: string, id: string) {
+    const bot = await botService.findByIdForUser(id, userId);
+    if (!bot) throw new ApiError(404, 'not_found', 'Bot not found');
+
+    const base = stripTrailingSlash(config.appBaseUrlBotServer);
+    const url = `${base}/bot/${id}/webhook`;
+
+    if (bot.status === 'connected' && bot.webhookUrl === url) {
+      return { status: 'connected', webhookUrl: url };
+    }
+
+    const token = decryptToken(bot.encryptedToken);
+    const apiBase = stripTrailingSlash(config.telegramApiBase);
+    const resp = await fetch(`${apiBase}/bot${token}/setWebhook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url,
+        secret_token: config.webhookSecret,
+        allowed_updates: ['message', 'my_chat_member', 'callback_query'],
+      }),
+    });
+    let data: TelegramApiResponse | undefined;
+    try {
+      data = (await resp.json()) as TelegramApiResponse;
+    } catch (_err) {
+      /* ignore */
+    }
+    if (!resp.ok || !data?.ok) {
+      await botService.updateForUser(id, userId, {
+        status: 'error',
+        lastError: data?.description,
+      });
+      throw new ApiError(
+        502,
+        'telegram_error',
+        data?.description || 'Failed to set webhook',
+      );
+    }
+
+    await botService.updateForUser(id, userId, {
+      status: 'connected',
+      webhookUrl: url,
+      lastError: null,
+    });
+    return { status: 'connected', webhookUrl: url };
+  }
+
+  async disconnectBot(userId: string, id: string) {
+    const bot = await botService.findByIdForUser(id, userId);
+    if (!bot) throw new ApiError(404, 'not_found', 'Bot not found');
+
+    if (bot.status === 'disconnected' && !bot.webhookUrl) {
+      return { status: 'disconnected' };
+    }
+
+    const token = decryptToken(bot.encryptedToken);
+    const apiBase = stripTrailingSlash(config.telegramApiBase);
+    const resp = await fetch(`${apiBase}/bot${token}/deleteWebhook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ drop_pending_updates: true }),
+    });
+    let data: TelegramApiResponse | undefined;
+    try {
+      data = (await resp.json()) as TelegramApiResponse;
+    } catch (_err) {
+      /* ignore */
+    }
+    if (!resp.ok || !data?.ok) {
+      await botService.updateForUser(id, userId, {
+        status: 'error',
+        lastError: data?.description,
+      });
+      throw new ApiError(
+        502,
+        'telegram_error',
+        data?.description || 'Failed to delete webhook',
+      );
+    }
+
+    await botService.updateForUser(id, userId, {
+      status: 'disconnected',
+      webhookUrl: null,
+      lastError: null,
+    });
+    return { status: 'disconnected' };
   }
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -29,6 +29,9 @@ model Bot {
   encryptedToken String
   tokenHash      String
   tokenLast4     String   @default("")
+  status         String   @default("disconnected")
+  webhookUrl     String?
+  lastError      String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 

--- a/packages/db/src/services/botService.ts
+++ b/packages/db/src/services/botService.ts
@@ -1,4 +1,10 @@
-import { Bot } from '@prisma/client';
+import { Bot as PrismaBot } from '@prisma/client';
+
+type Bot = PrismaBot & {
+  status: string;
+  webhookUrl: string | null;
+  lastError: string | null;
+};
 
 import { prisma } from '../prisma';
 
@@ -38,6 +44,9 @@ export const botService = {
         | 'encryptedToken'
         | 'tokenHash'
         | 'tokenLast4'
+        | 'status'
+        | 'webhookUrl'
+        | 'lastError'
       >
     >,
   ): Promise<Bot | null> {


### PR DESCRIPTION
## Summary
- add Telegram connect/disconnect endpoints and logic
- track bot connection status and webhook URL
- validate Telegram webhook secret in bot server

## Testing
- `pnpm --filter @botgrow/db install` *(fails: Failed to fetch sha256 checksum at binaries.prisma.sh)*
- `pnpm --filter @botgrow/core-api build` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `pnpm lint` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b066753784832494538c7bcc3ae2d1